### PR TITLE
Add cache memory usage log

### DIFF
--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -25,8 +25,9 @@ on:
 
 env:
   DOCKER_BUILDX_PLATFORM: linux/amd64
-  DOCKER_REGISTRY_OWNER: athenz
-  DOCKER_REGISTRY_USER: abvaidya
+  DOCKER_REGISTRY_ORG: athenz
+  # DOCKER_REGISTRY_USER: values for docker login is stored in repository variables
+  # DOCKER_REGISTRY_TOKEN_NAME: values for docker login is stored in repository variables
 
 jobs:
   build:
@@ -60,11 +61,8 @@ jobs:
         run: |
           # Use docker.io for Docker Hub if empty
           [[ "${{ env.DOCKER_REGISTRY_URL}}" = "" ]] && echo "DOCKER_REGISTRY_URL=docker.io" >> $GITHUB_ENV
-          [[ "${{ env.DOCKER_REGISTRY_OWNER }}" = "" ]] && echo "DOCKER_REGISTRY_OWNER=${{ env.CI_REPOSITORY_OWNER }}" >> $GITHUB_ENV
+          [[ "${{ env.DOCKER_REGISTRY_ORG }}" = "" ]] && echo "DOCKER_REGISTRY_ORG=${{ env.CI_REPOSITORY_OWNER }}" >> $GITHUB_ENV
           [[ "${{ env.DOCKER_REGISTRY_IMAGE }}" = "" ]] && echo "DOCKER_REGISTRY_IMAGE=${{ env.CI_REPOSITORY_NAME }}" >> $GITHUB_ENV
-          [[ "${{ env.DOCKER_REGISTRY_TOKEN}}" = "" ]] && echo "DOCKER_REGISTRY_TOKEN=${{ secrets.DOCKER_REGISTRY_TOKEN }}" >> $GITHUB_ENV
-          [[ "${{ env.DELETE_UNTAGGED_IMAGES_TOKEN }}" = "" ]] && echo "DELETE_UNTAGGED_IMAGES_TOKEN=${{ env.DOCKER_REGISTRY_TOKEN }}" >> $GITHUB_ENV
-          [[ "${{ env.DELETE_UNTAGGED_IMAGES_PER_PAGE }}" = "" ]] && echo "DELETE_UNTAGGED_IMAGES_PER_PAGE=100" >> $GITHUB_ENV
 
       # This action checks-out your repository under $GITHUB_WORKSPACE, so your workflow can access it.
       # https://github.com/actions/checkout
@@ -73,7 +71,7 @@ jobs:
         id: checkout
         # You may pin to the exact commit or the version.
         # uses: https://github.com/actions/checkout/tags
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # This action sets up a go environment for use in actions by:
       # - Optionally downloading and caching a version of Go by version and adding to PATH.
@@ -147,9 +145,9 @@ jobs:
         id: meta
         # You may pin to the exact commit or the version.
         # uses: https://github.com/docker/metadata-action/tags
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKER_REGISTRY_URL }}/${{ env.DOCKER_REGISTRY_OWNER }}/${{ env.DOCKER_REGISTRY_IMAGE }}
+          images: ${{ env.DOCKER_REGISTRY_URL }}/${{ env.DOCKER_REGISTRY_ORG }}/${{ env.DOCKER_REGISTRY_IMAGE }}
           # for latest tag
           # latest=auto for tagging latest only for "master" branch
           flavor: |
@@ -173,14 +171,14 @@ jobs:
         id: login
         # You may pin to the exact commit or the version.
         # uses: https://github.com/docker/login-action/tags
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           # Server address of Docker registry. If not set then will default to Docker Hub
           registry: ${{ env.DOCKER_REGISTRY_URL }} # optional
           # Username used to log against the Docker registry
-          username: ${{ env.DOCKER_REGISTRY_USER }} # optional
+          username: ${{ vars.DOCKER_REGISTRY_USER }} # optional
           # Password or personal access token used to log against the Docker registry
-          password: ${{ env.DOCKER_REGISTRY_TOKEN }} # optional
+          password: ${{ secrets[vars.DOCKER_REGISTRY_TOKEN_NAME] }} # optional
           # Log out from the Docker registry at the end of a job
           logout: true # optional, default is true
 
@@ -191,7 +189,7 @@ jobs:
         id: qemu
         # You may pin to the exact commit or the version.
         # uses: https://github.com/docker/setup-qemu-action/tags
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # GitHub Action to set up Docker Buildx.
       # https://github.com/docker/setup-buildx-action
@@ -200,7 +198,7 @@ jobs:
         id: buildx
         # You may pin to the exact commit or the version.
         # uses: https://github.com/docker/setup-buildx-action/tags
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -217,7 +215,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           # push: true
           # load: false
-          # tags: ${{ env.DOCKER_REGISTRY_URL }}/${{ env.DOCKER_REGISTRY_OWNER }}/${{ env.DOCKER_REGISTRY_IMAGE }}:nightly
+          # tags: ${{ env.DOCKER_REGISTRY_URL }}/${{ env.DOCKER_REGISTRY_ORG }}/${{ env.DOCKER_REGISTRY_IMAGE }}:nightly
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.DOCKER_BUILDX_PLATFORM }}
           build-args: |

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -2,6 +2,7 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: LY Corporation
+    copyright-year: '2023'
     software-name: athenz-client-sidecar
   paths:
     - '**/*.go'

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/AthenZ/athenz v1.11.32
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/kpango/fastime v1.1.9
-	github.com/kpango/gache v1.2.8
+	github.com/kpango/gache/v2 v2.0.9
 	github.com/kpango/glg v1.6.15
 	github.com/kpango/ntokend v1.0.12
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/q
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kpango/fastime v1.1.9 h1:xVQHcqyPt5M69DyFH7g1EPRns1YQNap9d5eLhl/Jy84=
 github.com/kpango/fastime v1.1.9/go.mod h1:vyD7FnUn08zxY4b/QFBZVG+9EWMYsNl+QF0uE46urD4=
-github.com/kpango/gache v1.2.8 h1:+OjREOmuWO4qrJksDhzWJq80o9iwHiezdVmMR1jtCG0=
-github.com/kpango/gache v1.2.8/go.mod h1:UyBo0IoPFDSJypK2haDXeV6PwHEmBcXQA0BLuOYEvWg=
+github.com/kpango/gache/v2 v2.0.9 h1:iov+hbPaKXDVjAFxmJ52Oso2VZyhcMiUkNlkq+OwylM=
+github.com/kpango/gache/v2 v2.0.9/go.mod h1:5AWVWlHau1dwI9Hzf+NZc4rPTwxM3SVwJQgob/OyAjQ=
 github.com/kpango/glg v1.6.15 h1:nw0xSxpSyrDIWHeb3dvnE08PW+SCbK+aYFETT75IeLA=
 github.com/kpango/glg v1.6.15/go.mod h1:cmsc7Yeu8AS3wHLmN7bhwENXOpxfq+QoqxCIk2FneRk=
 github.com/kpango/ntokend v1.0.12 h1:vWDaoNVLm+UJ/DymS+GHcHbgNW+/X7zcqH88ATOxgO0=

--- a/service/access.go
+++ b/service/access.go
@@ -364,9 +364,9 @@ func (a *accessService) updateAccessToken(ctx context.Context, domain, role, pro
 }
 
 func (a *accessService) storeTokenCache(key string, acd *accessCacheData, expTimeDelta time.Time, expTime *jwt.NumericDate) {
-	oldTokenCacheData, _ := a.tokenCache.Get(key)
+	oldTokenCacheData, ok := a.tokenCache.Get(key)
 	a.tokenCache.SetWithExpire(key, *acd, expTime.Sub(expTimeDelta))
-	if oldTokenCacheData != (accessCacheData{}) {
+	if ok {
 		oldTokenCacheSize := accessCacheMemoryUsage(&oldTokenCacheData)
 		a.memoryUsage += accessCacheMemoryUsage(acd) - oldTokenCacheSize
 		return

--- a/service/access.go
+++ b/service/access.go
@@ -372,15 +372,10 @@ func (a *accessService) updateAccessToken(ctx context.Context, domain, role, pro
 }
 
 func accessCacheMemoryUsage(acd *accessCacheData) int64 {
-	tokenSize := int64(unsafe.Sizeof(acd.token)) + int64(len(acd.token))
-	domainSize := int64(unsafe.Sizeof(acd.domain)) + int64(len(acd.domain))
-	roleSize := int64(unsafe.Sizeof(acd.role)) + int64(len(acd.role))
-	proxySize := int64(unsafe.Sizeof(acd.proxyForPrincipal)) + int64(len(acd.proxyForPrincipal))
-	expiresInSize := int64(unsafe.Sizeof(acd.expiresIn))
-	expirySize := int64(unsafe.Sizeof(acd.expiry))
-	scopeSize := int64(unsafe.Sizeof(acd.scope)) + int64(len(acd.scope))
+	structSize := int64(unsafe.Sizeof(acd.token) + unsafe.Sizeof(acd.domain) + unsafe.Sizeof(acd.role) + unsafe.Sizeof(acd.proxyForPrincipal) + unsafe.Sizeof(acd.expiresIn) + unsafe.Sizeof(acd.expiry) + unsafe.Sizeof(acd.scope))
+	stringSize := int64(len(acd.token) + len(acd.domain) + len(acd.role) + len(acd.proxyForPrincipal) + len(acd.scope))
 
-	return tokenSize + domainSize + roleSize + proxySize + expiresInSize + expirySize + scopeSize
+	return structSize + stringSize
 }
 
 // fetchAccessToken fetches the access token from Athenz server, and returns the AccessTokenResponse or any error occurred.

--- a/service/access.go
+++ b/service/access.go
@@ -290,7 +290,12 @@ func (a *accessService) RefreshAccessTokenCache(ctx context.Context) <-chan erro
 }
 
 func (a *accessService) TokenCacheLen() int {
-	return a.tokenCache.Len()
+	cacheLen := 0
+	a.tokenCache.Foreach(context.Background(), func(key string, val interface{}, exp int64) bool {
+		cacheLen += 1
+		return true
+	})
+	return cacheLen
 }
 
 func (a *accessService) TokenCacheSize() int64 {

--- a/service/access.go
+++ b/service/access.go
@@ -379,7 +379,7 @@ func (a *accessService) updateAccessToken(ctx context.Context, domain, role, pro
 }
 
 func accessCacheMemoryUsage(acd *accessCacheData) int64 {
-	structSize := int64(unsafe.Sizeof(acd.token) + unsafe.Sizeof(acd.domain) + unsafe.Sizeof(acd.role) + unsafe.Sizeof(acd.proxyForPrincipal) + unsafe.Sizeof(acd.expiresIn) + unsafe.Sizeof(acd.expiry) + unsafe.Sizeof(acd.scope))
+	structSize := int64(unsafe.Sizeof(*acd))
 	stringSize := int64(len(acd.token) + len(acd.domain) + len(acd.role) + len(acd.proxyForPrincipal) + len(acd.scope))
 
 	return structSize + stringSize

--- a/service/access.go
+++ b/service/access.go
@@ -374,7 +374,6 @@ func (a *accessService) storeTokenCache(key string, acd *accessCacheData, expTim
 			return
 		}
 		a.memoryUsage += accessCacheMemoryUsage(acd)
-		a.memoryUsage += int64(len(key))
 		return
 	}
 	a.memoryUsage += accessCacheMemoryUsage(acd) + int64(len(key))

--- a/service/access_mock.go
+++ b/service/access_mock.go
@@ -21,6 +21,8 @@ type AccessServiceMock struct {
 	StartAccessUpdaterFunc      func(context.Context) <-chan error
 	RefreshAccessTokenCacheFunc func(ctx context.Context) <-chan error
 	GetAccessProviderFunc       func() AccessProvider
+	TokenCacheLenFunc           func() int
+	TokenCacheSizeFunc          func() int64
 }
 
 // StartAccessUpdater is a mock implementation of AccessService.StartAccessUpdater
@@ -36,4 +38,12 @@ func (asm *AccessServiceMock) RefreshAccessTokenCache(ctx context.Context) <-cha
 // GetAccessProvider is a mock implementation of AccessService.GetAccessProvider
 func (asm *AccessServiceMock) GetAccessProvider() AccessProvider {
 	return asm.GetAccessProviderFunc()
+}
+
+func (asm *AccessServiceMock) TokenCacheLen() int {
+	return asm.TokenCacheLenFunc()
+}
+
+func (asm *AccessServiceMock) TokenCacheSize() int64 {
+	return asm.TokenCacheSizeFunc()
 }

--- a/service/access_test.go
+++ b/service/access_test.go
@@ -837,6 +837,12 @@ func Test_accessService_GetAccessProvider(t *testing.T) {
 	}
 }
 
+func Test_accessService_TokenCacheLen(t *testing.T) {
+}
+
+func Test_accessService_TokenCacheSize(t *testing.T) {
+}
+
 func Test_accessService_getAccessToken(t *testing.T) {
 	type fields struct {
 		cfg                   config.AccessToken

--- a/service/access_test.go
+++ b/service/access_test.go
@@ -2133,6 +2133,27 @@ func Test_accessService_storeTokenCache(t *testing.T) {
 				want: 126,
 			}
 		}(),
+		func() test {
+			tokenCache := gache.New()
+			tokenCache.SetWithExpire("dummy", "dummyCache", time.Minute)
+
+			return test{
+				name: "storeTokenCache store correct memoryUsage when old cache is not accessCacheData struct",
+				fields: fields{
+					tokenCache:  tokenCache,
+					memoryUsage: 111,
+				},
+				args: args{
+					key: "dummy",
+					acd: &accessCacheData{
+						token: "dummyToken2",
+					},
+					expTimeDelta: time.Now().Add(time.Minute),
+					expTime:      &jwt.NumericDate{Time: time.Now().Add(time.Minute)},
+				},
+				want: 245,
+			}
+		}(),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/service/access_test.go
+++ b/service/access_test.go
@@ -2133,28 +2133,6 @@ func Test_accessService_storeTokenCache(t *testing.T) {
 				want: 126,
 			}
 		}(),
-		func() test {
-			tokenCache := gache.New[accessCacheData]()
-			// tokenCache.SetWithExpire("dummy", "dummyCache", time.Minute)
-			tokenCache.SetWithExpire("dummy", accessCacheData{}, time.Minute)
-
-			return test{
-				name: "storeTokenCache store correct memoryUsage when old cache is not accessCacheData struct",
-				fields: fields{
-					tokenCache:  tokenCache,
-					memoryUsage: 111,
-				},
-				args: args{
-					key: "dummy",
-					acd: &accessCacheData{
-						token: "dummyToken2",
-					},
-					expTimeDelta: time.Now().Add(time.Minute),
-					expTime:      &jwt.NumericDate{Time: time.Now().Add(time.Minute)},
-				},
-				want: 250,
-			}
-		}(),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/service/access_test.go
+++ b/service/access_test.go
@@ -838,9 +838,159 @@ func Test_accessService_GetAccessProvider(t *testing.T) {
 }
 
 func Test_accessService_TokenCacheLen(t *testing.T) {
+	type fields struct {
+		cfg        config.AccessToken
+		token      ntokend.TokenProvider
+		tokenCache gache.Gache
+		expiry     time.Duration
+	}
+	type args struct {
+		ctx context.Context
+	}
+	type test struct {
+		name   string
+		fields fields
+		want   int
+	}
+	tests := []test{
+		func() test {
+			dummyExpiry := int64(1)
+			dummyToken, err := makeAccessTokenImpl("dummyDomain", "dummyRole", dummyExpiry)
+			if err != nil {
+				fmt.Errorf("Failed to make access token: %v", err)
+			}
+			tokenCache := gache.New()
+			tokenCache.SetWithExpire("dummyDomain;dummyRole", &accessCacheData{
+				token: dummyToken,
+			}, time.Minute)
+			return test{
+				name: "StartAccessUpdater can update cache periodically",
+				fields: fields{
+					tokenCache: tokenCache,
+					expiry:     time.Second,
+					token: func() (string, error) {
+						return "dummy N-token", nil
+					},
+				},
+				want: 1,
+			}
+		}(),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &accessService{
+				cfg:        tt.fields.cfg,
+				token:      tt.fields.token,
+				tokenCache: tt.fields.tokenCache,
+				expiry:     tt.fields.expiry,
+			}
+			got := a.TokenCacheLen()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("accessService.TokenCacheSize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func Test_accessService_TokenCacheSize(t *testing.T) {
+	type fields struct {
+		cfg                   config.AccessToken
+		token                 ntokend.TokenProvider
+		athenzURL             string
+		athenzPrincipleHeader string
+		tokenCache            gache.Gache
+		expiry                time.Duration
+		httpClient            atomic.Value
+	}
+	type args struct {
+		ctx               context.Context
+		domain            string
+		role              string
+		proxyForPrincipal string
+		expiresIn         int64
+	}
+	type test struct {
+		name      string
+		fields    fields
+		args      args
+		afterFunc func() error
+		want      int64
+	}
+	tests := []test{
+		func() test {
+			dummyTok, err := makeAccessTokenImpl("dummyDomain", "dummyRole", 60)
+			if err != nil {
+				fmt.Errorf("Failed to make access token: %v", err)
+			}
+			dummyExpTime := int64(999999999)
+			dummyToken := fmt.Sprintf(`{"access_token":"%v","token_type":"Bearer","expires_in":%v,"scope":"dummyDomain:dummyRole"}"`, dummyTok, dummyExpTime)
+
+			var sampleHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, dummyToken)
+			})
+			dummyServer := httptest.NewTLSServer(sampleHandler)
+
+			var httpClient atomic.Value
+			httpClient.Store(dummyServer.Client())
+			return test{
+				name: "Check correct size is output when cache exists",
+				fields: fields{
+					httpClient: httpClient,
+					tokenCache: gache.New(),
+					token: func() (string, error) {
+						return dummyToken, nil
+					},
+					athenzURL:             dummyServer.URL,
+					athenzPrincipleHeader: "Athenz-Principal",
+				},
+				args: args{
+					ctx:               context.Background(),
+					domain:            "dummyDomain",
+					role:              "dummyRole",
+					proxyForPrincipal: "dummyProxy",
+					expiresIn:         1,
+				},
+				afterFunc: func() error {
+					dummyServer.Close()
+					return nil
+				},
+				want: 426,
+			}
+		}(),
+	}
+	for _, tt := range tests {
+		if tt.afterFunc != nil {
+			defer func() {
+				err := tt.afterFunc()
+				if err != nil {
+					t.Errorf("accessService.TokenCacheSize() afterFunc error: %v", err)
+				}
+			}()
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			a := &accessService{
+				cfg:                   tt.fields.cfg,
+				token:                 tt.fields.token,
+				athenzURL:             tt.fields.athenzURL,
+				athenzPrincipleHeader: tt.fields.athenzPrincipleHeader,
+				tokenCache:            tt.fields.tokenCache,
+				expiry:                tt.fields.expiry,
+				httpClient:            tt.fields.httpClient,
+			}
+
+			_, err := a.updateAccessToken(tt.args.ctx, tt.args.domain, tt.args.role, tt.args.proxyForPrincipal, tt.args.expiresIn)
+			got := a.TokenCacheSize()
+			if err != nil {
+				t.Errorf("failed to updateAccessToken, err: %v", err)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("roleService.TokenCacheSize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func Test_accessService_getAccessToken(t *testing.T) {

--- a/service/access_test.go
+++ b/service/access_test.go
@@ -894,9 +894,9 @@ func Test_accessService_TokenCacheSize(t *testing.T) {
 			return test{
 				name: "TokenCacheSize exactly return memoryUsage field",
 				fields: fields{
-					memoryUsage: 100,
+					memoryUsage: 126,
 				},
-				want: 100,
+				want: 141,
 			}
 		}(),
 	}
@@ -2105,7 +2105,7 @@ func Test_accessService_storeTokenCache(t *testing.T) {
 					expTimeDelta: time.Now().Add(time.Minute),
 					expTime:      &jwt.NumericDate{Time: time.Now().Add(time.Minute)},
 				},
-				want: 111,
+				want: 124,
 			}
 		}(),
 		func() test {
@@ -2130,7 +2130,7 @@ func Test_accessService_storeTokenCache(t *testing.T) {
 					expTimeDelta: time.Now().Add(time.Minute),
 					expTime:      &jwt.NumericDate{Time: time.Now().Add(time.Minute)},
 				},
-				want: 112,
+				want: 126,
 			}
 		}(),
 	}

--- a/service/role.go
+++ b/service/role.go
@@ -364,15 +364,12 @@ func (r *roleService) updateRoleToken(ctx context.Context, domain, role, proxyFo
 }
 
 func roleCacheMemoryUsage(data *cacheData) int64 {
-	tokenSize := int64(unsafe.Sizeof(data.token)) + int64(len(data.token.Token))
-	expiryTimeSize := int64(unsafe.Sizeof(data.token.ExpiryTime)) + int64(len(strconv.FormatInt(data.token.ExpiryTime, 10)))
-	domainSize := int64(unsafe.Sizeof(data.domain)) + int64(len(data.domain))
-	roleSize := int64(unsafe.Sizeof(data.role)) + int64(len(data.role))
-	proxyForPrincipalSize := int64(unsafe.Sizeof(data.proxyForPrincipal)) + int64(len(data.proxyForPrincipal))
-	minExpirySize := int64(unsafe.Sizeof(data.minExpiry))
-	maxExpirySize := int64(unsafe.Sizeof(data.maxExpiry))
+	structSize := int64(unsafe.Sizeof(data.token) + unsafe.Sizeof(data.domain) + unsafe.Sizeof(data.role) + unsafe.Sizeof(data.proxyForPrincipal) + unsafe.Sizeof(data.minExpiry) + unsafe.Sizeof(data.maxExpiry))
+	stringSize := int64(len(data.domain) + len(data.role) + len(data.proxyForPrincipal))
+	rtStructSize := int64(unsafe.Sizeof(data.token.Token) + unsafe.Sizeof(data.token.ExpiryTime))
+	rtStringSize := int64(len(data.token.Token) + len(strconv.FormatInt(data.token.ExpiryTime, 10)))
 
-	return tokenSize + expiryTimeSize + domainSize + roleSize + proxyForPrincipalSize + minExpirySize + maxExpirySize
+	return structSize + stringSize + rtStructSize + rtStringSize
 }
 
 // fetchRoleToken fetch the role token from Athenz server, and return the decoded role token and any error if occurred.

--- a/service/role.go
+++ b/service/role.go
@@ -251,7 +251,6 @@ func (r *roleService) StartRoleUpdater(ctx context.Context) <-chan error {
 	r.domainRoleCache.EnableExpiredHook().SetExpiredHook(func(ctx context.Context, k string) {
 		glg.Warnf("the following cache is expired, key: %v", k)
 
-		// TODO:
 		if val, ok := r.domainRoleCache.Get(k); ok {
 			if data, ok := val.(*cacheData); ok {
 				size := roleCacheMemoryUsage(data)
@@ -299,12 +298,10 @@ func (r *roleService) RefreshRoleTokenCache(ctx context.Context) <-chan error {
 	return echan
 }
 
-// TODO:
 func (a *roleService) TokenCacheLen() int {
 	return a.domainRoleCache.Len()
 }
 
-// TODO:
 func (a *roleService) TokenCacheSize() int64 {
 	return a.memoryUsage
 }
@@ -355,6 +352,7 @@ func (r *roleService) updateRoleToken(ctx context.Context, domain, role, proxyFo
 
 		// TODO:
 		r.memoryUsage += roleCacheMemoryUsage(cd)
+		r.memoryUsage += int64(len(key))
 
 		glg.Debugf("token is cached, domain: %s, role: %s, proxyForPrincipal: %s, expiry time: %v", domain, role, proxyForPrincipal, rt.ExpiryTime)
 		return rt, nil

--- a/service/role.go
+++ b/service/role.go
@@ -361,8 +361,7 @@ func (r *roleService) storeTokenCache(key string, cd *cacheData, expTimeDelta ti
 	if ok {
 		r.memoryUsage.Add(roleCacheMemoryUsage(cd) - roleCacheMemoryUsage(&oldTokenCacheData))
 	} else {
-		tokenCacheSize := roleCacheMemoryUsage(cd)
-		r.memoryUsage.Add(tokenCacheSize + int64(len(key)))
+		r.memoryUsage.Add(roleCacheMemoryUsage(cd) + int64(len(key)))
 	}
 	return
 }

--- a/service/role.go
+++ b/service/role.go
@@ -293,7 +293,12 @@ func (r *roleService) RefreshRoleTokenCache(ctx context.Context) <-chan error {
 }
 
 func (r *roleService) TokenCacheLen() int {
-	return r.domainRoleCache.Len()
+	cacheLen := 0
+	r.domainRoleCache.Foreach(context.Background(), func(key string, val interface{}, exp int64) bool {
+		cacheLen += 1
+		return true
+	})
+	return cacheLen
 }
 
 func (r *roleService) TokenCacheSize() int64 {

--- a/service/role.go
+++ b/service/role.go
@@ -350,7 +350,6 @@ func (r *roleService) updateRoleToken(ctx context.Context, domain, role, proxyFo
 		}
 		r.domainRoleCache.SetWithExpire(key, cd, time.Unix(rt.ExpiryTime, 0).Sub(expTimeDelta))
 
-		// TODO:
 		r.memoryUsage += roleCacheMemoryUsage(cd)
 		r.memoryUsage += int64(len(key))
 
@@ -364,7 +363,6 @@ func (r *roleService) updateRoleToken(ctx context.Context, domain, role, proxyFo
 	return rt.(*RoleToken), err
 }
 
-// TODO:
 func roleCacheMemoryUsage(data *cacheData) int64 {
 	tokenSize := int64(unsafe.Sizeof(data.token)) + int64(len(data.token.Token))
 	expiryTimeSize := int64(unsafe.Sizeof(data.token.ExpiryTime)) + int64(len(strconv.FormatInt(data.token.ExpiryTime, 10)))

--- a/service/role.go
+++ b/service/role.go
@@ -356,9 +356,9 @@ func (r *roleService) updateRoleToken(ctx context.Context, domain, role, proxyFo
 }
 
 func (r *roleService) storeTokenCache(key string, cd *cacheData, expTimeDelta time.Time, expTime int64) {
-	oldTokenCacheData, _ := r.domainRoleCache.Get(key)
+	oldTokenCacheData, ok := r.domainRoleCache.Get(key)
 	r.domainRoleCache.SetWithExpire(key, *cd, time.Unix(expTime, 0).Sub(expTimeDelta))
-	if oldTokenCacheData != (cacheData{}) {
+	if ok {
 		oldTokenCacheSize := roleCacheMemoryUsage(&oldTokenCacheData)
 		r.memoryUsage += roleCacheMemoryUsage(cd) - oldTokenCacheSize
 	} else {

--- a/service/role_mock.go
+++ b/service/role_mock.go
@@ -21,6 +21,8 @@ type RoleServiceMock struct {
 	StartRoleUpdaterFunc      func(context.Context) <-chan error
 	RefreshRoleTokenCacheFunc func(ctx context.Context) <-chan error
 	GetRoleProviderFunc       func() RoleProvider
+	TokenCacheLenFunc         func() int
+	TokenCacheSizeFunc        func() int64
 }
 
 // StartRoleUpdater is a mock implementation of RoleService.StartRoleUpdater
@@ -36,4 +38,12 @@ func (asm *RoleServiceMock) RefreshRoleTokenCache(ctx context.Context) <-chan er
 // GetRoleProvider is a mock implementation of RoleService.GetRoleProvider
 func (asm *RoleServiceMock) GetRoleProvider() RoleProvider {
 	return asm.GetRoleProviderFunc()
+}
+
+func (asm *RoleServiceMock) TokenCacheLen() int {
+	return asm.TokenCacheLenFunc()
+}
+
+func (asm *RoleServiceMock) TokenCacheSize() int64 {
+	return asm.TokenCacheSizeFunc()
 }

--- a/service/role_test.go
+++ b/service/role_test.go
@@ -925,7 +925,7 @@ func Test_roleService_TokenCacheSize(t *testing.T) {
 					dummyServer.Close()
 					return nil
 				},
-				want: 161,
+				want: 177,
 			}
 		}(),
 	}

--- a/service/role_test.go
+++ b/service/role_test.go
@@ -496,6 +496,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 		athenzURL             string
 		athenzPrincipleHeader string
 		domainRoleCache       gache.Gache[cacheData]
+		memoryUsage           *atomic.Int64
 		expiry                time.Duration
 		httpClient            atomic.Value
 
@@ -544,6 +545,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 				fields: fields{
 					httpClient:            httpClient,
 					domainRoleCache:       domainRoleCache,
+					memoryUsage:           &atomic.Int64{},
 					expiry:                time.Second,
 					athenzURL:             dummyServer.URL,
 					athenzPrincipleHeader: "Athenz-Principal",
@@ -616,6 +618,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: domainRoleCache,
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return "dummyToken", nil
 					},
@@ -695,6 +698,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: domainRoleCache,
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return "dummyToken", nil
 					},
@@ -757,6 +761,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 				athenzURL:             tt.fields.athenzURL,
 				athenzPrincipleHeader: tt.fields.athenzPrincipleHeader,
 				domainRoleCache:       tt.fields.domainRoleCache,
+				memoryUsage:           tt.fields.memoryUsage,
 				expiry:                tt.fields.expiry,
 				httpClient:            tt.fields.httpClient,
 				refreshPeriod:         tt.fields.refreshPeriod,
@@ -843,21 +848,23 @@ func Test_roleService_TokenCacheLen(t *testing.T) {
 
 func Test_roleService_TokenCacheSize(t *testing.T) {
 	type fields struct {
-		memoryUsage int64
+		memoryUsage *atomic.Int64
 	}
 	type test struct {
-		name   string
-		fields fields
-		want   int64
+		name         string
+		fields       fields
+		initialValue int64
+		want         int64
 	}
 	tests := []test{
 		func() test {
 			return test{
 				name: "TokenCacheSize exactly return memoryUsage field",
 				fields: fields{
-					memoryUsage: 100,
+					memoryUsage: &atomic.Int64{},
 				},
-				want: 112,
+				initialValue: 100,
+				want:         112,
 			}
 		}(),
 	}
@@ -866,6 +873,7 @@ func Test_roleService_TokenCacheSize(t *testing.T) {
 			r := &roleService{
 				memoryUsage: tt.fields.memoryUsage,
 			}
+			r.memoryUsage.Store(tt.initialValue)
 			got := r.TokenCacheSize()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("roleService.TokenCacheSize() = %v, want %v", got, tt.want)
@@ -881,6 +889,7 @@ func Test_roleService_getRoleToken(t *testing.T) {
 		athenzURL             string
 		athenzPrincipleHeader string
 		domainRoleCache       gache.Gache[cacheData]
+		memoryUsage           *atomic.Int64
 		expiry                time.Duration
 		httpClient            atomic.Value
 	}
@@ -918,6 +927,7 @@ func Test_roleService_getRoleToken(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: gache.New[cacheData](),
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -955,6 +965,7 @@ func Test_roleService_getRoleToken(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: gache.New[cacheData](),
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return "", nil
 					},
@@ -1020,6 +1031,7 @@ func Test_roleService_getRoleToken(t *testing.T) {
 				athenzURL:             tt.fields.athenzURL,
 				athenzPrincipleHeader: tt.fields.athenzPrincipleHeader,
 				domainRoleCache:       tt.fields.domainRoleCache,
+				memoryUsage:           tt.fields.memoryUsage,
 				expiry:                tt.fields.expiry,
 				httpClient:            tt.fields.httpClient,
 			}
@@ -1047,6 +1059,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 		athenzURL             string
 		athenzPrincipleHeader string
 		domainRoleCache       gache.Gache[cacheData]
+		memoryUsage           atomic.Int64
 		expiry                time.Duration
 		httpClient            atomic.Value
 		refreshPeriod         time.Duration
@@ -1093,6 +1106,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 					athenzURL:             dummyServer.URL,
 					athenzPrincipleHeader: "dummy",
 					domainRoleCache:       roleCache,
+					memoryUsage:           atomic.Int64{},
 					expiry:                time.Minute,
 					httpClient:            httpClient,
 					refreshPeriod:         time.Second,
@@ -1163,6 +1177,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 					athenzURL:             dummyServer.URL,
 					athenzPrincipleHeader: "dummy",
 					domainRoleCache:       roleCache,
+					memoryUsage:           atomic.Int64{},
 					expiry:                time.Minute,
 					httpClient:            httpClient,
 					refreshPeriod:         time.Second,
@@ -1236,6 +1251,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: domainRoleCache,
+					memoryUsage:     atomic.Int64{},
 					token: func() (string, error) {
 						return "dummyToken", nil
 					},
@@ -1309,6 +1325,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: domainRoleCache,
+					memoryUsage:     atomic.Int64{},
 					token: func() (string, error) {
 						return "dummyToken", nil
 					},
@@ -1373,6 +1390,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 				athenzURL:             tt.fields.athenzURL,
 				athenzPrincipleHeader: tt.fields.athenzPrincipleHeader,
 				domainRoleCache:       tt.fields.domainRoleCache,
+				memoryUsage:           &tt.fields.memoryUsage,
 				expiry:                tt.fields.expiry,
 				httpClient:            tt.fields.httpClient,
 				refreshPeriod:         tt.fields.refreshPeriod,
@@ -1394,6 +1412,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 		athenzURL             string
 		athenzPrincipleHeader string
 		domainRoleCache       gache.Gache[cacheData]
+		memoryUsage           *atomic.Int64
 		expiry                time.Duration
 		httpClient            atomic.Value
 		refreshPeriod         time.Duration
@@ -1435,6 +1454,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: domainRoleCache,
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1495,6 +1515,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: domainRoleCache,
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1560,6 +1581,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: domainRoleCache,
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1617,6 +1639,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 				athenzURL:             tt.fields.athenzURL,
 				athenzPrincipleHeader: tt.fields.athenzPrincipleHeader,
 				domainRoleCache:       tt.fields.domainRoleCache,
+				memoryUsage:           tt.fields.memoryUsage,
 				expiry:                tt.fields.expiry,
 				httpClient:            tt.fields.httpClient,
 				refreshPeriod:         tt.fields.refreshPeriod,
@@ -1638,6 +1661,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 		athenzURL             string
 		athenzPrincipleHeader string
 		domainRoleCache       gache.Gache[cacheData]
+		memoryUsage           *atomic.Int64
 		expiry                time.Duration
 		httpClient            atomic.Value
 	}
@@ -1676,6 +1700,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: gache.New[cacheData](),
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1707,6 +1732,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				fields: fields{
 					httpClient:      atomic.Value{},
 					domainRoleCache: gache.New[cacheData](),
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return "", dummyErr
 					},
@@ -1740,6 +1766,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: gache.New[cacheData](),
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return "", nil
 					},
@@ -1774,6 +1801,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: gache.New[cacheData](),
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1810,6 +1838,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: gache.New[cacheData](),
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1850,6 +1879,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: roleRoleCache,
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1916,6 +1946,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				fields: fields{
 					httpClient:      httpClient,
 					domainRoleCache: domainRoleCache,
+					memoryUsage:     &atomic.Int64{},
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1968,6 +1999,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				athenzURL:             tt.fields.athenzURL,
 				athenzPrincipleHeader: tt.fields.athenzPrincipleHeader,
 				domainRoleCache:       tt.fields.domainRoleCache,
+				memoryUsage:           tt.fields.memoryUsage,
 				expiry:                tt.fields.expiry,
 				httpClient:            tt.fields.httpClient,
 			}
@@ -1998,7 +2030,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 func Test_roleService_storeTokenCache(t *testing.T) {
 	type fields struct {
 		domainRoleCache gache.Gache[cacheData]
-		memoryUsage     int64
+		memoryUsage     *atomic.Int64
 	}
 	type args struct {
 		key          string
@@ -2007,10 +2039,11 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 		expTime      int64
 	}
 	type test struct {
-		name   string
-		fields fields
-		args   args
-		want   int64
+		name         string
+		fields       fields
+		initialValue int64
+		args         args
+		want         int64
 	}
 	tests := []test{
 		func() test {
@@ -2018,7 +2051,7 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 				name: "storeTokenCache store correct memoryUsage when cache does not exist",
 				fields: fields{
 					domainRoleCache: gache.New[cacheData](),
-					memoryUsage:     0,
+					memoryUsage:     &atomic.Int64{},
 				},
 				args: args{
 					key: "dummy",
@@ -2052,8 +2085,9 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 				name: "storeTokenCache store correct memoryUsage when cache already exists",
 				fields: fields{
 					domainRoleCache: domainRoleCache,
-					memoryUsage:     126,
+					memoryUsage:     &atomic.Int64{},
 				},
+				initialValue: 126,
 				args: args{
 					key: "dummy",
 					cd: &cacheData{
@@ -2065,7 +2099,7 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 					expTimeDelta: time.Now().Add(time.Minute),
 					expTime:      0,
 				},
-				want: 141,
+				want: 142,
 			}
 		}(),
 	}
@@ -2075,7 +2109,7 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 				domainRoleCache: tt.fields.domainRoleCache,
 				memoryUsage:     tt.fields.memoryUsage,
 			}
-
+			r.memoryUsage.Store(tt.initialValue)
 			r.storeTokenCache(tt.args.key, tt.args.cd, tt.args.expTimeDelta, tt.args.expTime)
 			got := r.TokenCacheSize()
 			if !reflect.DeepEqual(got, tt.want) {

--- a/service/role_test.go
+++ b/service/role_test.go
@@ -925,7 +925,7 @@ func Test_roleService_TokenCacheSize(t *testing.T) {
 					dummyServer.Close()
 					return nil
 				},
-				want: 177,
+				want: 168,
 			}
 		}(),
 	}

--- a/service/role_test.go
+++ b/service/role_test.go
@@ -2065,7 +2065,7 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 					expTimeDelta: time.Now().Add(time.Minute),
 					expTime:      0,
 				},
-				want: 142,
+				want: 141,
 			}
 		}(),
 	}

--- a/service/role_test.go
+++ b/service/role_test.go
@@ -857,7 +857,7 @@ func Test_roleService_TokenCacheSize(t *testing.T) {
 				fields: fields{
 					memoryUsage: 100,
 				},
-				want: 100,
+				want: 112,
 			}
 		}(),
 	}
@@ -2031,7 +2031,7 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 					expTimeDelta: time.Now().Add(time.Minute),
 					expTime:      0,
 				},
-				want: 111,
+				want: 124,
 			}
 		}(),
 		func() test {
@@ -2052,7 +2052,7 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 				name: "storeTokenCache store correct memoryUsage when cache already exists",
 				fields: fields{
 					domainRoleCache: domainRoleCache,
-					memoryUsage:     111,
+					memoryUsage:     126,
 				},
 				args: args{
 					key: "dummy",
@@ -2065,7 +2065,7 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 					expTimeDelta: time.Now().Add(time.Minute),
 					expTime:      0,
 				},
-				want: 112,
+				want: 142,
 			}
 		}(),
 	}

--- a/service/role_test.go
+++ b/service/role_test.go
@@ -797,6 +797,12 @@ func Test_roleService_GetRoleProvider(t *testing.T) {
 	}
 }
 
+func Test_roleService_TokenCacheLen(t *testing.T) {
+}
+
+func Test_roleService_TokenCacheSize(t *testing.T) {
+}
+
 func Test_roleService_getRoleToken(t *testing.T) {
 	type fields struct {
 		cfg                   config.RoleToken

--- a/service/role_test.go
+++ b/service/role_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/AthenZ/athenz-client-sidecar/v2/config"
 	"github.com/kpango/fastime"
-	"github.com/kpango/gache"
+	"github.com/kpango/gache/v2"
 	"github.com/kpango/ntokend"
 	"github.com/pkg/errors"
 )
@@ -81,7 +81,7 @@ func TestNewRoleService(t *testing.T) {
 					token:                 args.token,
 					athenzURL:             args.cfg.AthenzURL,
 					athenzPrincipleHeader: args.cfg.PrincipalAuthHeader,
-					domainRoleCache:       gache.New(),
+					domainRoleCache:       gache.New[cacheData](),
 					expiry: func() time.Duration {
 						dur, _ := time.ParseDuration(args.cfg.Expiry)
 						return dur
@@ -123,7 +123,7 @@ func TestNewRoleService(t *testing.T) {
 					token:                 args.token,
 					athenzURL:             args.cfg.AthenzURL,
 					athenzPrincipleHeader: args.cfg.PrincipalAuthHeader,
-					domainRoleCache:       gache.New(),
+					domainRoleCache:       gache.New[cacheData](),
 					expiry:                0,
 					errRetryInterval:      defaultErrRetryInterval,
 					errRetryMaxCount:      defaultErrRetryMaxCount,
@@ -242,7 +242,7 @@ func TestNewRoleService(t *testing.T) {
 					token:                 args.token,
 					athenzURL:             args.cfg.AthenzURL,
 					athenzPrincipleHeader: args.cfg.PrincipalAuthHeader,
-					domainRoleCache:       gache.New(),
+					domainRoleCache:       gache.New[cacheData](),
 					expiry:                0,
 					errRetryInterval:      defaultErrRetryInterval,
 					errRetryMaxCount:      cnt,
@@ -291,7 +291,7 @@ func TestNewRoleService(t *testing.T) {
 					token:                 args.token,
 					athenzURL:             args.cfg.AthenzURL,
 					athenzPrincipleHeader: args.cfg.PrincipalAuthHeader,
-					domainRoleCache:       gache.New(),
+					domainRoleCache:       gache.New[cacheData](),
 					expiry:                0,
 					rootCAs:               cp,
 					errRetryInterval:      defaultErrRetryInterval,
@@ -339,7 +339,7 @@ func TestNewRoleService(t *testing.T) {
 					token:                 args.token,
 					athenzURL:             args.cfg.AthenzURL,
 					athenzPrincipleHeader: args.cfg.PrincipalAuthHeader,
-					domainRoleCache:       gache.New(),
+					domainRoleCache:       gache.New[cacheData](),
 					expiry:                0,
 					certPath:              "../test/data/dummyClient.crt",
 					certKeyPath:           "../test/data/dummyClient.key",
@@ -394,7 +394,7 @@ func TestNewRoleService(t *testing.T) {
 					token:                 args.token,
 					athenzURL:             args.cfg.AthenzURL,
 					athenzPrincipleHeader: args.cfg.PrincipalAuthHeader,
-					domainRoleCache:       gache.New(),
+					domainRoleCache:       gache.New[cacheData](),
 					expiry:                0,
 					certPath:              "",
 					certKeyPath:           "",
@@ -495,7 +495,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 		token                 ntokend.TokenProvider
 		athenzURL             string
 		athenzPrincipleHeader string
-		domainRoleCache       gache.Gache
+		domainRoleCache       gache.Gache[cacheData]
 		expiry                time.Duration
 		httpClient            atomic.Value
 
@@ -523,8 +523,8 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 				ExpiryTime: dummyExpTime,
 			}
 
-			domainRoleCache := gache.New()
-			domainRoleCache.SetWithExpire("dummyDomain;dummyRole", &cacheData{
+			domainRoleCache := gache.New[cacheData]()
+			domainRoleCache.SetWithExpire("dummyDomain;dummyRole", cacheData{
 				token: dummyRoleToken,
 			}, time.Minute)
 
@@ -596,7 +596,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			domainRoleCache := gache.New()
+			domainRoleCache := gache.New[cacheData]()
 			data := &cacheData{
 				token:             nil,
 				domain:            "dummyDomain",
@@ -605,7 +605,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 				minExpiry:         60,
 				maxExpiry:         60,
 			}
-			domainRoleCache.SetWithExpire("dummyDomain;dummyRole;dummyProxy", data, time.Minute)
+			domainRoleCache.SetWithExpire("dummyDomain;dummyRole;dummyProxy", *data, time.Minute)
 
 			ctx, cancel := context.WithCancel(context.Background())
 
@@ -657,7 +657,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 						return errors.New("token does not set to the cache")
 					}
 
-					if tok.(*cacheData).token.Token != dummyTok {
+					if tok.token.Token != dummyTok {
 						return errors.New("invalid token set on the cache")
 					}
 
@@ -672,7 +672,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			domainRoleCache := gache.New()
+			domainRoleCache := gache.New[cacheData]()
 			data := &cacheData{
 				token: &RoleToken{
 					Token:      dummyTok,
@@ -684,7 +684,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 				minExpiry:         60,
 				maxExpiry:         60,
 			}
-			domainRoleCache.SetWithExpire("dummyDomain;dummyRole;dummyProxy", data, time.Minute)
+			domainRoleCache.SetWithExpire("dummyDomain;dummyRole;dummyProxy", *data, time.Minute)
 
 			ctx, cancel := context.WithCancel(context.Background())
 
@@ -737,7 +737,7 @@ func Test_roleService_StartRoleUpdater(t *testing.T) {
 						return errors.New("token does not set to the cache")
 					}
 
-					if tok.(*cacheData).token.Token != dummyTok {
+					if tok.token.Token != dummyTok {
 						return errors.New("invalid token set on the cache")
 					}
 
@@ -799,7 +799,7 @@ func Test_roleService_GetRoleProvider(t *testing.T) {
 
 func Test_roleService_TokenCacheLen(t *testing.T) {
 	type fields struct {
-		domainRoleCache gache.Gache
+		domainRoleCache gache.Gache[cacheData]
 	}
 	type test struct {
 		name   string
@@ -815,8 +815,8 @@ func Test_roleService_TokenCacheLen(t *testing.T) {
 				Token:      dummyToken,
 				ExpiryTime: dummyExpTime,
 			}
-			domainRoleCache := gache.New()
-			domainRoleCache.SetWithExpire("dummy", &cacheData{
+			domainRoleCache := gache.New[cacheData]()
+			domainRoleCache.SetWithExpire("dummy", cacheData{
 				token: dummyRoleToken,
 			}, time.Minute)
 			return test{
@@ -880,7 +880,7 @@ func Test_roleService_getRoleToken(t *testing.T) {
 		token                 ntokend.TokenProvider
 		athenzURL             string
 		athenzPrincipleHeader string
-		domainRoleCache       gache.Gache
+		domainRoleCache       gache.Gache[cacheData]
 		expiry                time.Duration
 		httpClient            atomic.Value
 	}
@@ -917,7 +917,7 @@ func Test_roleService_getRoleToken(t *testing.T) {
 				name: "getRoleToken returns correct",
 				fields: fields{
 					httpClient:      httpClient,
-					domainRoleCache: gache.New(),
+					domainRoleCache: gache.New[cacheData](),
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -954,7 +954,7 @@ func Test_roleService_getRoleToken(t *testing.T) {
 				name: "getRoleToken returns error",
 				fields: fields{
 					httpClient:      httpClient,
-					domainRoleCache: gache.New(),
+					domainRoleCache: gache.New[cacheData](),
 					token: func() (string, error) {
 						return "", nil
 					},
@@ -983,8 +983,8 @@ func Test_roleService_getRoleToken(t *testing.T) {
 				Token:      dummyTok,
 				ExpiryTime: dummyExpTime,
 			}
-			gac := gache.New()
-			gac.Set("dummyDomain;dummyRole;dummyProxy", &cacheData{
+			gac := gache.New[cacheData]()
+			gac.Set("dummyDomain;dummyRole;dummyProxy", cacheData{
 				token: dummyRoleToken,
 			})
 
@@ -1046,7 +1046,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 		token                 ntokend.TokenProvider
 		athenzURL             string
 		athenzPrincipleHeader string
-		domainRoleCache       gache.Gache
+		domainRoleCache       gache.Gache[cacheData]
 		expiry                time.Duration
 		httpClient            atomic.Value
 		refreshPeriod         time.Duration
@@ -1071,7 +1071,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			roleCache := gache.New()
+			roleCache := gache.New[cacheData]()
 			data := &cacheData{
 				token:             nil,
 				domain:            "dummyDomain",
@@ -1080,7 +1080,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 				minExpiry:         60,
 				maxExpiry:         60,
 			}
-			roleCache.SetWithExpire("dummyDomain;dummyRole", data, time.Minute)
+			roleCache.SetWithExpire("dummyDomain;dummyRole", *data, time.Minute)
 
 			var httpClient atomic.Value
 			httpClient.Store(dummyServer.Client())
@@ -1112,7 +1112,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 						return errors.New("cannot get new token")
 					}
 
-					tok := newCache.(*cacheData).token
+					tok := newCache.token
 					if tok == nil {
 						return errors.New("updated token is nil")
 					}
@@ -1131,7 +1131,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			roleCache := gache.New()
+			roleCache := gache.New[cacheData]()
 			data := &cacheData{
 				token:             nil,
 				domain:            "dummyDomain",
@@ -1140,7 +1140,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 				minExpiry:         60,
 				maxExpiry:         60,
 			}
-			roleCache.SetWithExpire("dummyDomain;dummyRole", data, time.Minute)
+			roleCache.SetWithExpire("dummyDomain;dummyRole", *data, time.Minute)
 
 			data1 := &cacheData{
 				token:             nil,
@@ -1150,7 +1150,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 				minExpiry:         60,
 				maxExpiry:         60,
 			}
-			roleCache.SetWithExpire("dummyDomain1;dummyRole1", data1, time.Minute)
+			roleCache.SetWithExpire("dummyDomain1;dummyRole1", *data1, time.Minute)
 
 			var httpClient atomic.Value
 			httpClient.Store(dummyServer.Client())
@@ -1183,7 +1183,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 							return errors.New("cannot get new token")
 						}
 
-						tok := newCache.(*cacheData).token
+						tok := newCache.token
 						if tok == nil {
 							return errors.New("updated token is nil")
 						}
@@ -1218,7 +1218,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			domainRoleCache := gache.New()
+			domainRoleCache := gache.New[cacheData]()
 			data := &cacheData{
 				token:             nil,
 				domain:            "dummyDomain",
@@ -1227,7 +1227,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 				minExpiry:         60,
 				maxExpiry:         60,
 			}
-			domainRoleCache.SetWithExpire("dummyDomain;dummyRole;dummyProxy", data, time.Minute)
+			domainRoleCache.SetWithExpire("dummyDomain;dummyRole;dummyProxy", *data, time.Minute)
 
 			var httpClient atomic.Value
 			httpClient.Store(dummyServer.Client())
@@ -1269,7 +1269,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 						return errors.New("token does not set to the cache")
 					}
 
-					if tok.(*cacheData).token.Token != dummyTok {
+					if tok.token.Token != dummyTok {
 						return errors.New("invalid token set on the cache")
 					}
 
@@ -1288,7 +1288,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			domainRoleCache := gache.New()
+			domainRoleCache := gache.New[cacheData]()
 			data := &cacheData{
 				token: &RoleToken{
 					Token:      dummyTok,
@@ -1300,7 +1300,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 				minExpiry:         60,
 				maxExpiry:         60,
 			}
-			domainRoleCache.SetWithExpire("dummyDomain;dummyRole;dummyProxy", data, time.Minute)
+			domainRoleCache.SetWithExpire("dummyDomain;dummyRole;dummyProxy", *data, time.Minute)
 
 			var httpClient atomic.Value
 			httpClient.Store(dummyServer.Client())
@@ -1343,7 +1343,7 @@ func Test_roleService_RefreshRoleTokenCache(t *testing.T) {
 						return errors.New("token does not set to the cache")
 					}
 
-					if tok.(*cacheData).token.Token != dummyTok {
+					if tok.token.Token != dummyTok {
 						return errors.New("invalid token set on the cache")
 					}
 
@@ -1393,7 +1393,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 		token                 ntokend.TokenProvider
 		athenzURL             string
 		athenzPrincipleHeader string
-		domainRoleCache       gache.Gache
+		domainRoleCache       gache.Gache[cacheData]
 		expiry                time.Duration
 		httpClient            atomic.Value
 		refreshPeriod         time.Duration
@@ -1426,7 +1426,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			domainRoleCache := gache.New()
+			domainRoleCache := gache.New[cacheData]()
 
 			var httpClient atomic.Value
 			httpClient.Store(dummyServer.Client())
@@ -1458,7 +1458,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 						return errors.New("token is not set to the cache")
 					}
 
-					if tok.(*cacheData).token.Token != dummyTok {
+					if tok.token.Token != dummyTok {
 						return errors.New("invalid token set on the cache")
 					}
 
@@ -1486,7 +1486,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			domainRoleCache := gache.New()
+			domainRoleCache := gache.New[cacheData]()
 
 			var httpClient atomic.Value
 			httpClient.Store(dummyServer.Client())
@@ -1531,7 +1531,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 						return errors.New("token is not set to the cache")
 					}
 
-					if tok.(*cacheData).token.Token != dummyTok {
+					if tok.token.Token != dummyTok {
 						return errors.New("invalid token set on the cache")
 					}
 
@@ -1551,7 +1551,7 @@ func Test_roleService_updateRoleTokenWithRetry(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			domainRoleCache := gache.New()
+			domainRoleCache := gache.New[cacheData]()
 
 			var httpClient atomic.Value
 			httpClient.Store(dummyServer.Client())
@@ -1637,7 +1637,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 		token                 ntokend.TokenProvider
 		athenzURL             string
 		athenzPrincipleHeader string
-		domainRoleCache       gache.Gache
+		domainRoleCache       gache.Gache[cacheData]
 		expiry                time.Duration
 		httpClient            atomic.Value
 	}
@@ -1675,7 +1675,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				name: "updateRoleToken returns correct",
 				fields: fields{
 					httpClient:      httpClient,
-					domainRoleCache: gache.New(),
+					domainRoleCache: gache.New[cacheData](),
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1706,7 +1706,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				name: "updateRoleToken token returns error",
 				fields: fields{
 					httpClient:      atomic.Value{},
-					domainRoleCache: gache.New(),
+					domainRoleCache: gache.New[cacheData](),
 					token: func() (string, error) {
 						return "", dummyErr
 					},
@@ -1739,7 +1739,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				name: "updateRoleToken new request returns error",
 				fields: fields{
 					httpClient:      httpClient,
-					domainRoleCache: gache.New(),
+					domainRoleCache: gache.New[cacheData](),
 					token: func() (string, error) {
 						return "", nil
 					},
@@ -1773,7 +1773,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				name: "updateRoleToken get token error",
 				fields: fields{
 					httpClient:      httpClient,
-					domainRoleCache: gache.New(),
+					domainRoleCache: gache.New[cacheData](),
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1809,7 +1809,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				name: "updateRoleToken decode token error",
 				fields: fields{
 					httpClient:      httpClient,
-					domainRoleCache: gache.New(),
+					domainRoleCache: gache.New[cacheData](),
 					token: func() (string, error) {
 						return dummyToken, nil
 					},
@@ -1841,7 +1841,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			roleRoleCache := gache.New()
+			roleRoleCache := gache.New[cacheData]()
 
 			var httpClient atomic.Value
 			httpClient.Store(dummyServer.Client())
@@ -1869,7 +1869,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 					if !ok {
 						return fmt.Errorf("element cannot found in cache")
 					}
-					if c.(*cacheData).token.Token != dummyTok {
+					if c.token.Token != dummyTok {
 						return fmt.Errorf("token not matched, got: %v, want: %v", c, dummyTok)
 					}
 
@@ -1896,7 +1896,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 			})
 			dummyServer := httptest.NewTLSServer(sampleHandler)
 
-			domainRoleCache := gache.New()
+			domainRoleCache := gache.New[cacheData]()
 
 			// set another dummy token and see if it is updated
 			dummyTok2 := "dummyToken2"
@@ -1905,7 +1905,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 				Token:      dummyToken2,
 				ExpiryTime: dummyExpTime.UnixNano() / int64(time.Second),
 			}
-			domainRoleCache.SetWithExpire("dummyDomain;dummyRole", &cacheData{
+			domainRoleCache.SetWithExpire("dummyDomain;dummyRole", cacheData{
 				token: dummyRoleToke2,
 			}, time.Second)
 
@@ -1935,7 +1935,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 					if !ok {
 						return fmt.Errorf("element cannot found in cache")
 					}
-					if tok.(*cacheData).token.Token != dummyTok {
+					if tok.token.Token != dummyTok {
 						return fmt.Errorf("Token not updated")
 					}
 
@@ -1997,7 +1997,7 @@ func Test_roleService_updateRoleToken(t *testing.T) {
 
 func Test_roleService_storeTokenCache(t *testing.T) {
 	type fields struct {
-		domainRoleCache gache.Gache
+		domainRoleCache gache.Gache[cacheData]
 		memoryUsage     int64
 	}
 	type args struct {
@@ -2017,7 +2017,7 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 			return test{
 				name: "storeTokenCache store correct memoryUsage when cache does not exist",
 				fields: fields{
-					domainRoleCache: gache.New(),
+					domainRoleCache: gache.New[cacheData](),
 					memoryUsage:     0,
 				},
 				args: args{
@@ -2043,8 +2043,8 @@ func Test_roleService_storeTokenCache(t *testing.T) {
 				ExpiryTime: dummyExpTime,
 			}
 
-			domainRoleCache := gache.New()
-			domainRoleCache.Set("dummy", &cacheData{
+			domainRoleCache := gache.New[cacheData]()
+			domainRoleCache.Set("dummy", cacheData{
 				token: roleToken,
 			})
 
@@ -2150,7 +2150,7 @@ func Test_roleService_fetchRoleToken(t *testing.T) {
 		token                 ntokend.TokenProvider
 		athenzURL             string
 		athenzPrincipleHeader string
-		domainRoleCache       gache.Gache
+		domainRoleCache       gache.Gache[cacheData]
 		expiry                time.Duration
 		httpClient            atomic.Value
 		rootCAs               *x509.CertPool
@@ -2473,7 +2473,7 @@ func Test_roleService_getCache(t *testing.T) {
 		token                 ntokend.TokenProvider
 		athenzURL             string
 		athenzPrincipleHeader string
-		domainRoleCache       gache.Gache
+		domainRoleCache       gache.Gache[cacheData]
 		expiry                time.Duration
 	}
 	type args struct {
@@ -2493,7 +2493,7 @@ func Test_roleService_getCache(t *testing.T) {
 			return test{
 				name: "getCache return not ok (cache not exist)",
 				fields: fields{
-					domainRoleCache: gache.New(),
+					domainRoleCache: gache.New[cacheData](),
 				},
 				args: args{
 					domain:    "dummyDomain",
@@ -2514,8 +2514,8 @@ func Test_roleService_getCache(t *testing.T) {
 				ExpiryTime: dummyExpTime,
 			}
 
-			domainRoleCache := gache.New()
-			domainRoleCache.Set("dummyDomain;dummyRole;principal", &cacheData{
+			domainRoleCache := gache.New[cacheData]()
+			domainRoleCache.Set("dummyDomain;dummyRole;principal", cacheData{
 				token: roleToken,
 			})
 
@@ -2664,7 +2664,7 @@ func Test_createGetRoleTokenRequest(t *testing.T) {
 		token                 ntokend.TokenProvider
 		athenzURL             string
 		athenzPrincipleHeader string
-		domainRoleCache       gache.Gache
+		domainRoleCache       gache.Gache[cacheData]
 		expiry                time.Duration
 	}
 	type args struct {

--- a/usecase/tenantd.go
+++ b/usecase/tenantd.go
@@ -205,19 +205,30 @@ func report(t *clientd) {
 	sysMemValue := validSample(samples[0])
 	heapMemValue := validSample(samples[1])
 	releasedHeapMemValue := validSample(samples[2])
+	sysMemInUse := sysMemValue - releasedHeapMemValue
 
 	// gather token cache metrics
-	atcSize := t.access.TokenCacheSize()
-	atcLen := t.access.TokenCacheLen()
-	rtcSize := t.role.TokenCacheSize()
-	rtcLen := t.role.TokenCacheLen()
+	var (
+		atcSize, rtcSize int64
+		atcLen, rtcLen   int
+	)
+	if t.access != nil {
+		atcSize = t.access.TokenCacheSize()
+		atcLen = t.access.TokenCacheLen()
+	}
+	if t.role != nil {
+		rtcSize = t.role.TokenCacheSize()
+		rtcLen = t.role.TokenCacheLen()
+	}
+	totalSize := atcSize + rtcSize
+	totalLen := atcLen + rtcLen
 
 	// report as log message
 	toMB := func(f float64) float64 {
 		return f / 1024 / 1024
 	}
 
-	glg.Infof("system_memory_inuse[%.1fMB]; go_memstats_heap_alloc_bytes[%.1fMB]; accesstoken:cached_token_bytes[%.1fMB],entries[%d]; roletoken:cached_token_bytes[%.1fMB],entries[%d]; total:cached_token_bytes[%.1fMB],entries[%d]; cache_token_ratio:sys[%.1f%%],heap[%.1f%%]", toMB(sysMemValue-releasedHeapMemValue), toMB(heapMemValue), toMB(float64(atcSize)), atcLen, toMB(float64(rtcSize)), rtcLen, toMB(float64(atcSize+rtcSize)), atcLen+rtcLen, float64(atcSize+rtcSize)/sysMemValue*100, float64(atcSize+rtcSize)/heapMemValue*100)
+	glg.Infof("system_memory_inuse[%.1fMB]; go_memstats_heap_alloc_bytes[%.1fMB]; accesstoken:cached_token_bytes[%.1fMB],entries[%d]; roletoken:cached_token_bytes[%.1fMB],entries[%d]; total:cached_token_bytes[%.1fMB],entries[%d]; cache_token_ratio:sys[%.1f%%],heap[%.1f%%]", toMB(sysMemInUse), toMB(heapMemValue), toMB(float64(atcSize)), atcLen, toMB(float64(rtcSize)), rtcLen, toMB(float64(totalSize)), totalLen, float64(totalSize)/sysMemInUse*100, float64(totalSize)/heapMemValue*100)
 }
 
 // createNtokend returns a TokenService object or any error

--- a/usecase/tenantd.go
+++ b/usecase/tenantd.go
@@ -217,7 +217,7 @@ func report(t *clientd) {
 		return f / 1024 / 1024
 	}
 
-	glg.Infof("system_memory_inuse[%.1fMB]; go_memstats_heap_alloc_bytes[%.1fMB]; accesstoken:cached_token_bytes[%.1fMB],entries[%d]; roletoken:cached_token_bytes[%.1fMB],entries[%d]; cache_token_ratio:sys[%.1f%%],heap[%.1f%%]", toMB(sysMemValue-releasedHeapMemValue), toMB(heapMemValue), toMB(float64(atcSize)), atcLen, toMB(float64(rtcSize)), rtcLen, float64(atcSize+rtcSize)/sysMemValue*100, float64(atcSize+rtcSize)/heapMemValue*100)
+	glg.Infof("system_memory_inuse[%.1fMB]; go_memstats_heap_alloc_bytes[%.1fMB]; accesstoken:cached_token_bytes[%.1fMB],entries[%d]; roletoken:cached_token_bytes[%.1fMB],entries[%d]; total:cached_token_bytes[%.1fMB],entries[%d]; cache_token_ratio:sys[%.1f%%],heap[%.1f%%]", toMB(sysMemValue-releasedHeapMemValue), toMB(heapMemValue), toMB(float64(atcSize)), atcLen, toMB(float64(rtcSize)), rtcLen, toMB(float64(atcSize+rtcSize)), atcLen+rtcLen, float64(atcSize+rtcSize)/sysMemValue*100, float64(atcSize+rtcSize)/heapMemValue*100)
 }
 
 // createNtokend returns a TokenService object or any error

--- a/usecase/tenantd.go
+++ b/usecase/tenantd.go
@@ -158,6 +158,7 @@ func (t *clientd) Start(ctx context.Context) chan []error {
 		}()
 	}
 
+	// start token cache report daemon (no need for graceful shutdown)
 	reportTicker := time.NewTicker(time.Minute)
 	go func() {
 		defer reportTicker.Stop()
@@ -174,7 +175,6 @@ func (t *clientd) Start(ctx context.Context) chan []error {
 	return t.server.ListenAndServe(ctx)
 }
 
-// start token cache report daemon (no need for graceful shutdown)
 func report(t *clientd) {
 	// gather golang metrics
 	const sysMemMetric = "/memory/classes/total:bytes"                  // go_memstats_sys_bytes
@@ -213,11 +213,11 @@ func report(t *clientd) {
 		atcLen, rtcLen   int
 	)
 	if t.access != nil {
-		atcSize = int64(float64(t.access.TokenCacheSize()) * 1.125)
+		atcSize = t.access.TokenCacheSize()
 		atcLen = t.access.TokenCacheLen()
 	}
 	if t.role != nil {
-		rtcSize = int64(float64(t.role.TokenCacheSize()) * 1.125)
+		rtcSize = t.role.TokenCacheSize()
 		rtcLen = t.role.TokenCacheLen()
 	}
 	totalSize := atcSize + rtcSize

--- a/usecase/tenantd.go
+++ b/usecase/tenantd.go
@@ -213,11 +213,11 @@ func report(t *clientd) {
 		atcLen, rtcLen   int
 	)
 	if t.access != nil {
-		atcSize = t.access.TokenCacheSize()
+		atcSize = int64(float64(t.access.TokenCacheSize()) * 1.125)
 		atcLen = t.access.TokenCacheLen()
 	}
 	if t.role != nil {
-		rtcSize = t.role.TokenCacheSize()
+		rtcSize = int64(float64(t.role.TokenCacheSize()) * 1.125)
 		rtcLen = t.role.TokenCacheLen()
 	}
 	totalSize := atcSize + rtcSize

--- a/usecase/tenantd.go
+++ b/usecase/tenantd.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"runtime/metrics"
 	"time"
 
 	"github.com/AthenZ/athenz-client-sidecar/v2/config"
@@ -156,7 +157,67 @@ func (t *clientd) Start(ctx context.Context) chan []error {
 			}
 		}()
 	}
+
+	reportTicker := time.NewTicker(time.Minute)
+	go func() {
+		defer reportTicker.Stop()
+		for {
+			select {
+			case <-reportTicker.C:
+				report(t)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	return t.server.ListenAndServe(ctx)
+}
+
+// start token cache report daemon (no need for graceful shutdown)
+func report(t *clientd) {
+	// gather golang metrics
+	const sysMemMetric = "/memory/classes/total:bytes"                  // go_memstats_sys_bytes
+	const heapMemMetric = "/memory/classes/heap/objects:bytes"          // go_memstats_heap_alloc_bytes
+	const releasedHeapMemMetric = "/memory/classes/heap/released:bytes" // go_memstats_heap_released_bytes
+	// https://pkg.go.dev/runtime/metrics#pkg-examples
+	// https://github.com/prometheus/client_golang/blob/3f8bd73e9b6d1e20e8e1536622bd0fda8bb3cb50/prometheus/go_collector_latest.go#L32
+	samples := make([]metrics.Sample, 3)
+	samples[0].Name = sysMemMetric
+	samples[1].Name = heapMemMetric
+	samples[2].Name = releasedHeapMemMetric
+	metrics.Read(samples)
+	validSample := func(s metrics.Sample) float64 {
+		name, value := s.Name, s.Value
+		switch value.Kind() {
+		case metrics.KindUint64:
+			return float64(value.Uint64())
+		case metrics.KindFloat64:
+			return value.Float64()
+		case metrics.KindBad:
+			// Check if the metric is actually supported. If it's not, the resulting value will always have kind KindBad.
+			panic(fmt.Sprintf("%q: metric is no longer supported", name))
+		default:
+			// Check if the metrics specification has changed.
+			panic(fmt.Sprintf("%q: unexpected metric Kind: %v\n", name, value.Kind()))
+		}
+	}
+	sysMemValue := validSample(samples[0])
+	heapMemValue := validSample(samples[1])
+	releasedHeapMemValue := validSample(samples[2])
+
+	// gather token cache metrics
+	atcSize := t.access.TokenCacheSize()
+	atcLen := t.access.TokenCacheLen()
+	rtcSize := t.role.TokenCacheSize()
+	rtcLen := t.role.TokenCacheLen()
+
+	// report as log message
+	toMB := func(f float64) float64 {
+		return f / 1024 / 1024
+	}
+
+	glg.Infof("system_memory_inuse[%.1fMB]; go_memstats_heap_alloc_bytes[%.1fMB]; accesstoken:cached_token_bytes[%.1fMB],entries[%d]; roletoken:cached_token_bytes[%.1fMB],entries[%d]; cache_token_ratio:sys[%.1f%%],heap[%.1f%%]", toMB(sysMemValue-releasedHeapMemValue), toMB(heapMemValue), toMB(float64(atcSize)), atcLen, toMB(float64(rtcSize)), rtcLen, float64(atcSize+rtcSize)/sysMemValue*100, float64(atcSize+rtcSize)/heapMemValue*100)
 }
 
 // createNtokend returns a TokenService object or any error


### PR DESCRIPTION
# Description

Add cache memory usage log

```bash
2023-12-26 10:42:06     [INFO]: system_memory_inuse[946.1MB]; go_memstats_heap_alloc_bytes[691.2MB]; accesstoken:cached_token_bytes[389.6MB],entries[400000]; roletoken:cached_token_bytes[303.8MB],entries[400000]; total:cached_token_bytes[693.4MB],entries[800000]; cache_token_ratio:sys[73.3%],heap[100.3%]
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Passed all pipeline checking

## Checklist for maintainer

- Use `Squash and merge`
- Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- Delete the branch after merge
